### PR TITLE
refactor: アプリ設計上の課題を解消し、ユニットテストを整備する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ YouTubeの動画をダウンロードするためのFastAPI製REST API(`app/main
 - Lint: `ruff check .`(コンテナ内、`/usr/src/app` から実行)
 - フォーマット: `ruff format .`
 - 型チェック: `mypy .`(**兄弟リポジトリと同じくCIでは実行していない**ため、ローカルで随時実行すること)
-- テスト: `pytest`(**現時点でテストファイルは1件も無い**。pytest/pytest-cov と `[tool.pytest.ini_options]` は用意済みなので、`app/tests/` を作れば動く。CI(`test.yaml`)の `[ -d tests ]` ガードにより、`tests/` が無い間はスキップされる)
+- テスト: `pytest`(`app/tests/` 配下。CI(`test.yaml`)でも `dev` イメージの中で実行される)
 - 依存関係インストール(コンテナ内): `poetry install`(開発用)または `poetry install --without dev`(本番用)
 - 本番ビルド: `docker build --target prd .` / `docker compose -f compose.prd.yml up`
 
@@ -82,15 +82,17 @@ YouTubeの動画をダウンロードするためのFastAPI製REST API(`app/main
 - **`prd` にはシェルが無い**ため、`CMD` はexec形式で指定する必要がある(`python -m uvicorn ...`)。`docker compose exec` などでシェルに入ることもできないので、調査は `dev` イメージで行うこと。
 - **Poetryのpackage-modeは無効化**(`app/pyproject.toml` の `package-mode = false`)— 配布可能なパッケージではなく、単なるアプリケーションとして扱っている。
 - **Ruff/mypy/pytestの設定**: `app/pyproject.toml`。兄弟リポジトリと同一の内容に揃えている。Ruffは `select = ["ALL"]` + 広範な `ignore` リストではなく `select = ["B", "E", "F", "I", "N", "W", "C90", "PL", "RUF", "UP"]` という絞り込んだルールセット(line-length 119、`target-version = "py313"`)。mypyは `disallow_untyped_defs` / `warn_return_any` などを有効にした比較的厳格な設定。pytestは `testpaths = ["tests"]` / `pythonpath = ["."]`。**ruff/mypy自体のバージョンは揃えていない**(このリポジトリは ruff `^0.15.1` / mypy `^1.16.0`、兄弟は `^0.16.0` / `^2.0.0`)— 設定を新たに導入するタイミングでツールのメジャーバージョンまで同時に動かすと切り分けが難しくなるため、バージョンの追随はRenovateのPRに委ねている。
+- **テストは fakeredis で実Redisを模す**(`app/tests/`): `conftest.py` の `fake_redis` フィクスチャがテストごとに独立したインメモリRedisを返す。`download_queue` は検証対象がハッシュ・リスト・`blpop` といったRedisのデータ構造そのものなので、mockで「hsetをこの引数で呼んだか」を見るのではなく、**実際にコマンドを実行して結果の状態でアサートする**。一方 `RedisConnector` は「プールを正しいパラメータで1度だけ作るか」が検証対象でRedisの振る舞いは関係ないため、兄弟リポジトリと同じく `unittest.mock` で `redis.ConnectionPool` をパッチしている。
+  - **testcontainersを採用していない理由**: CIは `docker run --rm test-image:latest ... pytest` の形で**テストをコンテナの中で実行している**ため、testcontainersを使うとテストコンテナ内から更にDockerを叩く必要があり、dockerソケットのマウントと `dev` イメージへのdockerクライアント追加が要る(DHI移行の方向性にも、「テストは本番と同じイメージの中で動かす」というCI設計にも反する)。加えて `compose.yml` には既に `redis-service` が居るため、ローカルで実Redisを使いたい場合はtestcontainers無しでそこへ繋げばよい。現在使っているコマンドは `hset`/`hgetall`/`rpush`/`blpop`/`delete` だけで、いずれもfakeredisが忠実に模せる範囲にある。Luaスクリプト・Cluster・実際の接続断など**fakeredisが模しきれない領域を検証したくなった時点で見直す**こと。
+  - ワーカーの検証は `test_download_queue.py` に集約し、エンドポイントの検証(`test_main.py`)では `settings.download_workers` を0にしてワーカーを起動しない。こうしないとPOSTしたタスクがアサート前に `processing` へ進んでしまい、テストが不安定になる。
 - **JSON形式のアプリケーションログ**(`app/core/log_modules.py` の `log_application(name)`): `TimeStampFormatter` が `settings.tz`(既定 `Asia/Tokyo`、compose の `TZ` 環境変数と揃える)を使ってタイムスタンプをローカル時刻のISO8601で出力し、`LogApplicationJSONFormatter` が `timestamp`/`level`/`message`/`service`/`tag`/`details`(`function`/`argument`/`error_message`/`stacktrace`)のJSONを1行で出力する。`routers/youtube_download_router.py` は素の `logging.basicConfig` ではなくこの `log_application(__name__)` を使うこと。**`zoneinfo` がタイムゾーンデータを解決できるよう `tzdata` を明示的に依存関係へ追加している** — これによりイメージ側のOS tzdata(`/usr/share/zoneinfo`)の有無に左右されなくなり、最小構成の `dhi.io/python:3` でもJSTで出力される(`PYTHONTZPATH=""` でOS側を無効化した状態でも `+09:00` で出ることを確認済み)。**移行前は `logging.Formatter.formatTime`(= libcのローカル時刻)に依存していたため、DHI移行によってログのタイムスタンプが黙ってUTCへ変わる懸念があった**が、この移行で解消している。
 - 両方のcomposeファイルで `TZ=Asia/Tokyo` を指定している — スケジューリングや時刻を扱う機能を追加する際もこれを維持すること。
 
 ## 既知の技術的負債(未対応)
 
-基盤(ブランチ運用・CI/CD・Renovate・Dockerfile・ログモジュール・Ruff/mypy/pytest設定)の移行を先に済ませたため、以下は**意図的に手つかずのまま残している**。着手する際はこの順序を目安にすること。
+基盤の移行(ブランチ運用・CI/CD・Renovate・Dockerfile・ログモジュール・Ruff/mypy/pytest設定)とアプリ設計の整理、ユニットテストの整備を済ませた時点で、以下が**意図的に手つかずのまま残っている**。
 
-1. **テストファイルが1件も無い** — pytest/pytest-cov と `[tool.pytest.ini_options]` は導入済みなので、あとは `app/tests/` 配下にユニットテストを置くだけ。`test.yaml` の `[ -d tests ]` ガードにより、`tests/` が出来た時点で自動的にCIで走り始める。兄弟リポジトリの `app/tests/`(`test_main.py`/`test_redis_module.py`/`test_log_modules.py`)が参考になる。
-2. **uvicorn側のログ設定が無い** — アプリケーションログ(`core/log_modules.py`)はJSON化したが、uvicornが出すアクセスログ・起動ログは素のままなので、1つのコンテナから2種類のフォーマットのログが出ている状態。`log_config.yaml` を用意してアクセスログもJSON化し、ヘルスチェックの除外フィルタを入れるとよい。**これはASGIサーバーを持たない兄弟リポジトリには存在しない、このリポジトリ固有の作業**(兄弟の `core/log_modules.py` にも対応物が無い)。
-3. **mypyをCIで実行していない** — `[tool.mypy]` の設定自体は入っており `mypy .` はクリーンに通るが、`test.yaml` にステップが無いためローカルでしか実行されない。これは兄弟リポジトリと同じ状態(揃ってはいる)だが、CIで実行しないと徐々に壊れていくため、両リポジトリ揃ってステップを足すのが望ましい。
-4. **複数レプリカ運用時の同時ダウンロード数** — 同時実行数はワーカー本数で制御しているが、これは**1プロセス内での上限**でしかない。レプリカを増やすとその数だけ並列度も倍加する(`blpop` によりジョブ自体の重複処理は起きない)。全体で上限を設けたい場合はRedis側にセマフォを持たせるなどの仕組みが要る。
-5. **ダウンロード中にプロセスが落ちるとタスクが `processing` のまま残る** — `blpop` でキューから取り出した後にプロセスが停止すると、そのジョブはキューにもワーカーにも存在しないまま、ステータスだけ `processing` で残留する。厳密にやるなら処理中ジョブを別のリストへ退避する信頼性キュー(`lmove` を使うパターン)が必要。現状は `DELETE /download/all` で手動リセットする運用。
+1. **uvicorn側のログ設定が無い** — アプリケーションログ(`core/log_modules.py`)はJSON化したが、uvicornが出すアクセスログ・起動ログは素のままなので、1つのコンテナから2種類のフォーマットのログが出ている状態。`log_config.yaml` を用意してアクセスログもJSON化し、ヘルスチェックの除外フィルタを入れるとよい。**これはASGIサーバーを持たない兄弟リポジトリには存在しない、このリポジトリ固有の作業**(兄弟の `core/log_modules.py` にも対応物が無い)。
+2. **mypyをCIで実行していない** — `[tool.mypy]` の設定自体は入っており `mypy .` はクリーンに通るが、`test.yaml` にステップが無いためローカルでしか実行されない。これは兄弟リポジトリと同じ状態(揃ってはいる)だが、CIで実行しないと徐々に壊れていくため、両リポジトリ揃ってステップを足すのが望ましい。
+3. **複数レプリカ運用時の同時ダウンロード数** — 同時実行数はワーカー本数で制御しているが、これは**1プロセス内での上限**でしかない。レプリカを増やすとその数だけ並列度も倍加する(`blpop` によりジョブ自体の重複処理は起きない)。全体で上限を設けたい場合はRedis側にセマフォを持たせるなどの仕組みが要る。
+4. **ダウンロード中にプロセスが落ちるとタスクが `processing` のまま残る** — `blpop` でキューから取り出した後にプロセスが停止すると、そのジョブはキューにもワーカーにも存在しないまま、ステータスだけ `processing` で残留する。厳密にやるなら処理中ジョブを別のリストへ退避する信頼性キュー(`lmove` を使うパターン)が必要。現状は `DELETE /download/all` で手動リセットする運用。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,10 +67,14 @@ YouTubeの動画をダウンロードするためのFastAPI製REST API(`app/main
 
 ## アーキテクチャ
 
-- **FastAPIアプリ**: `main.py` が `lifespan` で `RedisConnector().get_connection()` を `app.state.redis` に格納し、2つのrouterを `settings.prefix_url` 付きで登録する。`redoc_url=None`(ReDocは無効、Swagger UIのみ)。
+- **FastAPIアプリ**: `main.py` の `lifespan` がRedis接続を `app.state.redis` へ格納し、ダウンロードワーカーを起動し、2つのrouterを `settings.prefix_url` 付きで登録する。`redoc_url=None`(ReDocは無効、Swagger UIのみ)。
   - `routers/operation_check.py` — 疎通確認用。`/`(docsへリダイレクト)、`/operation`、`/operation/ip`、`/operation/gzip-test`。
-  - `routers/youtube_download_router.py` — 本体。`POST /download`、`GET /download/status`、`DELETE /download/all` と、yt-dlpを叩く処理(`process_queue`/`download_youtube`/`get_youtube_title`)。
-- **キュー処理はリクエスト駆動**: `POST /download` が `BackgroundTasks` で `process_queue` を起動し、Redisのリスト(`youtube_download_queue`)が空になるまで `lpop` し続ける。**常駐ワーカーではないため、POSTが来ないと積まれたジョブは処理されない**(下記「既知の負債」参照)。
+  - `routers/youtube_download_router.py` — HTTP層のみ。`POST /download`、`GET /download/status`、`DELETE /download/all` の3エンドポイントで、Redis操作は `modules/download_queue.py` 越しに行う。
+  - `modules/download_queue.py` — キュー(リスト)とステータス(ハッシュ)の読み書き、および常駐ワーカー(`run_worker`)。
+  - `modules/youtube_module.py` — yt-dlpの呼び出し(`download_youtube`/`get_youtube_title`)。
+- **キューの消化は常駐ワーカーが行う**: `lifespan` が `settings.download_workers` 本(既定1)のワーカータスクを起動し、各ワーカーが `blpop` でキューを待ち受ける。`POST /download` はキューへ積むだけで、ダウンロード自体には関与しない。**ワーカーの本数がそのまま同時ダウンロード数の上限**になる。Redisの `blpop` もyt-dlpのダウンロードもブロッキングなので、どちらも `asyncio.to_thread` でスレッドへ逃がしイベントループを止めない。**移行前は `POST /download` が `BackgroundTasks` で `process_queue` を起動する方式だったため、POSTが来ないと積まれたジョブが処理されず、逆に同時POSTの分だけ無制限に並列ダウンロードが走っていた**。
+- **ワーカーの停止**: `lifespan` の終了時に停止フラグ(`asyncio.Event`)を立て、処理中のダウンロードが終わるのを `settings.worker_shutdown_timeout_seconds` まで待ってから、待ち切れなかったワーカーだけキャンセルする。ワーカーが `blpop` で待機している場合は最大 `settings.queue_pop_timeout_seconds` 秒で停止に反応する。最後に `RedisConnector.close()` でプールを切断する。
+- **ワーカーは1件の失敗では止まらない**: ジョブ処理中の例外はステータスを `error` にした上で握り潰し、Redisの接続エラーは `settings.queue_error_backoff_seconds` 待ってから再試行する。**常駐ワーカーがループを抜けると以降のジョブが一切消化されなくなる**ため、意図的に広く捕捉している(移行前の `process_queue` はRedisエラーで `break` していたが、リクエスト毎に起動し直されるため問題にならなかった)。
 - **マルチステージDockerfile**: `ffmpeg` / `base`(`dhi.io/python:3-debian-dev`) → `dependencies` → `dev-dependencies` → `dev` / `prd`。OpenShift向けのUBIベースイメージではなく、通常のKubernetes環境向けにDocker Hardened Images (DHI) を使用している。ビルド系のステージ(`base`/`dependencies`/`dev-dependencies`/`dev`)は開発ツール入りの `-debian-dev` バリアントを使うが、`prd` だけは `base` を継承せず最小構成の `dhi.io/python:3` から独立して作っている(実行時イメージに開発ツールを含めないため)。ステージ名は兄弟リポジトリに合わせて `dev`/`prd` に統一している(以前は `develop`/`production`)。
 - **ffmpegは静的ビルドのバイナリを `mwader/static-ffmpeg` からCOPYする**: yt-dlpが映像と音声を別々に取得してmp4へマージするためにffmpegが必須だが、本番用の `dhi.io/python:3` は最小構成でパッケージマネージャを持たないため `apt-get install ffmpeg` ができない。このイメージが提供する `/ffmpeg`・`/ffprobe` は外部依存を持たない静的PIEバイナリなので、共有ライブラリを持ち込むことなくバイナリ2個のCOPYだけで済む。`dev`/`prd` の両ステージへ入れている。**このイメージは `docker.io` 由来のため、ワークフローのログイン順序に制約が生まれている**(前述の「`docker.io` へのログインは必ずビルドより後」を参照)。
 - **Poetryの依存関係はプロジェクト内 `.venv` に分離**(`POETRY_VIRTUALENVS_CREATE=true` + `POETRY_VIRTUALENVS_IN_PROJECT=true`)。`dependencies` ステージで `poetry config virtualenvs.options.no-pip true` を設定し、`.venv` に `pip` 自体を含めない(本番イメージにpip由来の脆弱性が紛れ込むのを防ぐため)。`dev`/`prd` はいずれも `dependencies`/`dev-dependencies` ステージから `.venv` の中身だけを `COPY --from` で引き継ぎ、poetry自身やビルド専用の依存(setuptoolsなど)は最終イメージに含めない。`dev` は `dev-dependencies`(devグループ込み)から、`prd` は `dependencies`(本番依存のみ)から `.venv` をコピーする。**移行前は `poetry config virtualenvs.create false` でシステムのsite-packagesへ直接インストールし、poetry本体を `goegoe0212/poetry-image:latest` という個人アカウントの浮動タグから持ち込んでいた**が、DHI移行に伴いどちらも解消した。
@@ -88,10 +92,5 @@ YouTubeの動画をダウンロードするためのFastAPI製REST API(`app/main
 1. **テストファイルが1件も無い** — pytest/pytest-cov と `[tool.pytest.ini_options]` は導入済みなので、あとは `app/tests/` 配下にユニットテストを置くだけ。`test.yaml` の `[ -d tests ]` ガードにより、`tests/` が出来た時点で自動的にCIで走り始める。兄弟リポジトリの `app/tests/`(`test_main.py`/`test_redis_module.py`/`test_log_modules.py`)が参考になる。
 2. **uvicorn側のログ設定が無い** — アプリケーションログ(`core/log_modules.py`)はJSON化したが、uvicornが出すアクセスログ・起動ログは素のままなので、1つのコンテナから2種類のフォーマットのログが出ている状態。`log_config.yaml` を用意してアクセスログもJSON化し、ヘルスチェックの除外フィルタを入れるとよい。**これはASGIサーバーを持たない兄弟リポジトリには存在しない、このリポジトリ固有の作業**(兄弟の `core/log_modules.py` にも対応物が無い)。
 3. **mypyをCIで実行していない** — `[tool.mypy]` の設定自体は入っており `mypy .` はクリーンに通るが、`test.yaml` にステップが無いためローカルでしか実行されない。これは兄弟リポジトリと同じ状態(揃ってはいる)だが、CIで実行しないと徐々に壊れていくため、両リポジトリ揃ってステップを足すのが望ましい。
-4. **アプリ設計上の課題**:
-   - キューの消化が `BackgroundTasks` によるリクエスト駆動で、POSTが来ないと処理されない。逆に同時POSTの分だけ並列にダウンロードが走り、同時実行数の制御が無い。
-   - バックグラウンド処理へ `Request` オブジェクトをそのまま渡し、レスポンス送出後に `request.app.state.redis` を参照している。
-   - `video_title if "video_title" in locals() else "unknown"` という `locals()` を使った実装。
-   - `RedisConnector._initialize_pool` が `redis.ConnectionError` を捕まえて `HTTPException` を投げているが、**ConnectionPoolの生成はソケット接続を伴わない**(実際の接続は最初のコマンド発行時)ため、この例外処理は実質デッドコード。兄弟リポジトリでは既に同じ問題を認識して削除・コメント化済み。
-   - `lifespan` に終了処理(Redis接続のクローズ)が無い。
-   - `DELETE /download/all` はステータスハッシュしか消さないため、キュー(`youtube_download_queue`)に未処理ジョブが残っていると、その後のPOSTを契機に「ステータスの無いジョブ」が処理されうる。
+4. **複数レプリカ運用時の同時ダウンロード数** — 同時実行数はワーカー本数で制御しているが、これは**1プロセス内での上限**でしかない。レプリカを増やすとその数だけ並列度も倍加する(`blpop` によりジョブ自体の重複処理は起きない)。全体で上限を設けたい場合はRedis側にセマフォを持たせるなどの仕組みが要る。
+5. **ダウンロード中にプロセスが落ちるとタスクが `processing` のまま残る** — `blpop` でキューから取り出した後にプロセスが停止すると、そのジョブはキューにもワーカーにも存在しないまま、ステータスだけ `processing` で残留する。厳密にやるなら処理中ジョブを別のリストへ退避する信頼性キュー(`lmove` を使うパターン)が必要。現状は `DELETE /download/all` で手動リセットする運用。

--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,55 @@
+import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from core.log_modules import log_application
+from modules.download_queue import run_worker
 from modules.redis_module import RedisConnector
 from routers import operation_check, youtube_download_router
 from settings.config import settings
 
+logger = log_application(__name__)
+
 
 @asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator:
-    app.state.redis = RedisConnector().get_connection()
-    yield
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Redis接続とダウンロードワーカーのライフサイクルを管理する。
+
+    キューの消化はリクエスト駆動(BackgroundTasks)ではなく、ここで起動する
+    常駐ワーカーが行う。これによりPOSTが来なくても積まれたジョブが処理され、
+    同時ダウンロード数もワーカー本数で上限が決まる。
+    """
+    redis_connector = RedisConnector()
+    redis_client = redis_connector.get_connection()
+    app.state.redis = redis_client
+
+    stop_event = asyncio.Event()
+    workers = [
+        asyncio.create_task(
+            run_worker(redis_client, stop_event, f"worker-{index}"),
+            name=f"download-worker-{index}",
+        )
+        for index in range(settings.download_workers)
+    ]
+    logger.info("ダウンロードワーカーを %s 個起動しました", len(workers))
+
+    try:
+        yield
+    finally:
+        # 処理中のダウンロードが終わるのを待ってから停止する。待ち切れなかった
+        # ワーカーだけキャンセルし、シャットダウンが無限に延びないようにする。
+        stop_event.set()
+        if workers:
+            _done, pending = await asyncio.wait(workers, timeout=settings.worker_shutdown_timeout_seconds)
+            for task in pending:
+                logger.warning("ワーカー %s の終了を待てなかったためキャンセルします", task.get_name())
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+        redis_connector.close()
+        logger.info("Redis接続をクローズしました")
 
 
 app = FastAPI(

--- a/app/modules/download_queue.py
+++ b/app/modules/download_queue.py
@@ -1,0 +1,137 @@
+"""ダウンロードキューとタスク状態をRedis上で扱うモジュール。
+
+キュー(リスト)とタスク状態(ハッシュ)の読み書き、およびキューを消化し続ける
+常駐ワーカーを提供する。HTTP層(routers)はこのモジュール越しにRedisを触る。
+"""
+
+import asyncio
+import contextlib
+import json
+import uuid
+from typing import Any
+
+import redis
+
+from core.log_modules import log_application
+from modules.youtube_module import download_youtube, get_youtube_title
+from settings.config import settings
+
+logger = log_application(__name__)
+
+# home-discord-bot と共有しているキー。ステータスハッシュの値のスキーマ
+# (status / error / title)まで含めてプロセス間の契約になっているため、
+# 変更する場合は必ずボット側と同時に行うこと(CLAUDE.md参照)。
+REDIS_QUEUE_KEY = "youtube_download_queue"
+REDIS_STATUS_KEY = "youtube_download_statuses"
+
+
+def write_status(
+    redis_client: redis.Redis,
+    task_id: str,
+    status: str,
+    *,
+    title: str | None = None,
+    error: str | None = None,
+) -> None:
+    """タスクの状態をステータスハッシュへ書き込む。
+
+    title はタイトルが判明している場合のみキーごと含める。ボット側は title が
+    無い場合に「タイトル取得中」へフォールバックするため、未確定の段階で
+    null を書き込まないようにしている。
+    """
+    payload: dict[str, str | None] = {"status": status, "error": error}
+    if title is not None:
+        payload["title"] = title
+    redis_client.hset(REDIS_STATUS_KEY, task_id, json.dumps(payload))
+
+
+def enqueue(redis_client: redis.Redis, url: str) -> str:
+    """URLをキューへ積み、採番したタスクIDを返す。"""
+    task_id = str(uuid.uuid4())
+    write_status(redis_client, task_id, "queued")
+    redis_client.rpush(REDIS_QUEUE_KEY, json.dumps({"task_id": task_id, "url": url}))
+    return task_id
+
+
+def fetch_statuses(redis_client: redis.Redis) -> dict[str, Any]:
+    """全タスクの状態を取得する。"""
+    statuses: dict[str, str] = redis_client.hgetall(REDIS_STATUS_KEY)  # type: ignore[assignment]
+    return {task_id: json.loads(value) for task_id, value in statuses.items()}
+
+
+def clear_all(redis_client: redis.Redis) -> None:
+    """全タスクの状態と、未処理のキューをまとめて削除する。
+
+    ステータスだけを消すとキューに残ったジョブが後から「状態の無いジョブ」として
+    処理されてしまうため、キューも併せて削除する。ボットが持つ
+    youtube_download_notified_statuses はボット側の管轄なので触らない
+    (ステータスが消えたことをボット自身が検知して片付ける)。
+    """
+    redis_client.delete(REDIS_STATUS_KEY, REDIS_QUEUE_KEY)
+
+
+def pop_job(redis_client: redis.Redis) -> dict[str, str] | None:
+    """キューからジョブを1件取り出す。timeout まで待って空ならNoneを返す。"""
+    popped = redis_client.blpop([REDIS_QUEUE_KEY], timeout=settings.queue_pop_timeout_seconds)
+    if popped is None:
+        return None
+    _, raw_job = popped
+    job: dict[str, str] = json.loads(raw_job)
+    return job
+
+
+def process_job(redis_client: redis.Redis, job: dict[str, str]) -> None:
+    """ジョブ1件を処理し、進捗をステータスハッシュへ反映する。"""
+    task_id = job["task_id"]
+    url = job["url"]
+    # タイトル取得より前で失敗した場合に備えて先に初期化しておく
+    # (以前は except 節で locals() を覗いて判定していた)。
+    video_title = "unknown"
+    try:
+        video_title = get_youtube_title(url)
+        write_status(redis_client, task_id, "processing", title=video_title)
+        download_youtube(url, settings.output_dir)
+        write_status(redis_client, task_id, "done", title=video_title)
+    except Exception as e:
+        logger.exception("タスク %s のダウンロードに失敗しました", task_id)
+        write_status(redis_client, task_id, "error", title=video_title, error=str(e))
+
+
+async def _sleep_or_stop(stop_event: asyncio.Event, seconds: float) -> None:
+    """stop_event がセットされるまで、最大 seconds 秒待つ。
+
+    素の asyncio.sleep で待つとバックオフ中はシャットダウンに反応できないため、
+    停止指示が来た時点で待機を打ち切れるようにしている。
+    """
+    with contextlib.suppress(TimeoutError):
+        await asyncio.wait_for(stop_event.wait(), timeout=seconds)
+
+
+async def run_worker(redis_client: redis.Redis, stop_event: asyncio.Event, name: str) -> None:
+    """キューを消化し続ける常駐ワーカー。
+
+    Redisの blpop も yt-dlp のダウンロードもブロッキングなので、どちらも
+    asyncio.to_thread でスレッドへ逃がし、イベントループを止めないようにする。
+    ワーカーの本数(settings.download_workers)がそのまま同時ダウンロード数の
+    上限になる。
+    """
+    logger.info("ダウンロードワーカー %s を開始しました", name)
+    while not stop_event.is_set():
+        try:
+            job = await asyncio.to_thread(pop_job, redis_client)
+        except redis.RedisError:
+            logger.exception("キューの取得に失敗しました。%s秒後に再試行します", settings.queue_error_backoff_seconds)
+            await _sleep_or_stop(stop_event, settings.queue_error_backoff_seconds)
+            continue
+
+        if job is None:
+            continue
+
+        try:
+            await asyncio.to_thread(process_job, redis_client, job)
+        except Exception:
+            # 1件の失敗でワーカーを落とさない。ここで抜けると以降のジョブが
+            # 一切消化されなくなるため、意図的に広く捕捉している。
+            logger.exception("ジョブの処理中に想定外のエラーが発生しました")
+
+    logger.info("ダウンロードワーカー %s を停止しました", name)

--- a/app/modules/redis_module.py
+++ b/app/modules/redis_module.py
@@ -1,5 +1,4 @@
 import redis
-from fastapi import HTTPException
 
 from settings.config import settings
 
@@ -17,19 +16,21 @@ class RedisConnector:
         self._pool: redis.ConnectionPool | None = None
         self.max_connections = max_connections
 
-    def _initialize_pool(self) -> None:
-        if self._pool is None:
-            try:
-                self._pool = redis.ConnectionPool(
-                    host=self.host,
-                    port=self.port,
-                    max_connections=self.max_connections,
-                    decode_responses=True,
-                )
-            except redis.ConnectionError as e:
-                raise HTTPException(status_code=500, detail=f"Redis connection error: {e!s}") from e
-
     def get_connection(self) -> redis.Redis:
+        # ConnectionPoolの生成はソケット接続を伴わない(実際の接続は最初のコマンド発行時に
+        # 遅延で行われる)ため、ここでの接続エラーハンドリングは意味を持たない。
+        # 接続エラーは実際にコマンドを実行する呼び出し元で捕捉すること。
         if self._pool is None:
-            self._initialize_pool()
+            self._pool = redis.ConnectionPool(
+                host=self.host,
+                port=self.port,
+                max_connections=self.max_connections,
+                decode_responses=True,
+            )
         return redis.Redis(connection_pool=self._pool)
+
+    def close(self) -> None:
+        """プール内の接続を切断する。アプリ終了時(lifespan)に呼ぶ。"""
+        if self._pool is not None:
+            self._pool.disconnect()
+            self._pool = None

--- a/app/modules/youtube_module.py
+++ b/app/modules/youtube_module.py
@@ -1,0 +1,27 @@
+"""yt-dlpを呼び出して動画のダウンロード・情報取得を行うモジュール。"""
+
+from pathlib import Path
+
+from yt_dlp import YoutubeDL  # type: ignore[import]
+
+
+def download_youtube(url: str, output_dir: str) -> None:
+    """URLの動画をmp4として output_dir へ保存する。"""
+    path_out_dir = Path(output_dir)
+    ydl_opts = {
+        "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+        "outtmpl": str(path_out_dir / "%(title).50s.mp4"),
+        "merge_output_format": "mp4",
+        "postprocessors": [],
+    }
+    with YoutubeDL(ydl_opts) as ydl:
+        ydl.download([url])
+
+
+def get_youtube_title(url: str) -> str:
+    """URLの動画タイトルを取得する(ダウンロードは行わない)。"""
+    with YoutubeDL({"quiet": True}) as ydl:
+        info = ydl.extract_info(url, download=False)
+        # yt-dlpは型スタブを持たずextract_infoの戻り値がAnyになるため、
+        # str()で明示的に確定させる(mypyのwarn_return_any対策も兼ねる)。
+        return str(info.get("title", "unknown"))

--- a/app/poetry.lock
+++ b/app/poetry.lock
@@ -205,6 +205,31 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "fakeredis"
+version = "2.37.0"
+description = "Python implementation of redis API, can be used for testing purposes."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "fakeredis-2.37.0-py3-none-any.whl", hash = "sha256:657a2a695a1123be0c13f98db409371497bd94c29d260dd76a9fc7ce1a633745"},
+    {file = "fakeredis-2.37.0.tar.gz", hash = "sha256:7461f124dcba04a80691d72270b3d1d5cd100ef14dc068c76db825940f3ed799"},
+]
+
+[package.dependencies]
+redis = {version = ">=4.3", markers = "python_version > \"3.8\""}
+sortedcontainers = ">=2"
+
+[package.extras]
+bf = ["pyprobables (>=0.6)"]
+cf = ["pyprobables (>=0.6)"]
+json = ["jsonpath-ng (>=1.6)"]
+lua = ["lupa (>=2.1)"]
+probabilistic = ["pyprobables (>=0.6)"]
+valkey = ["valkey (>=6) ; python_version >= \"3.8\""]
+vectorset = ["jsonpath-ng (>=1.6) ; python_version >= \"3.11\"", "numpy (>=2.4.0) ; python_version >= \"3.11\""]
+
+[[package]]
 name = "fastapi"
 version = "0.129.0"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -891,7 +916,7 @@ version = "7.2.0"
 description = "Python client for Redis database and key-value store"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "redis-7.2.0-py3-none-any.whl", hash = "sha256:01f591f8598e483f1842d429e8ae3a820804566f1c73dca1b80e23af9fba0497"},
     {file = "redis-7.2.0.tar.gz", hash = "sha256:4dd5bf4bd4ae80510267f14185a15cba2a38666b941aff68cccf0256b51c1f26"},
@@ -931,6 +956,18 @@ files = [
     {file = "ruff-0.15.1-py3-none-win_amd64.whl", hash = "sha256:c820fef9dd5d4172a6570e5721704a96c6679b80cf7be41659ed439653f62336"},
     {file = "ruff-0.15.1-py3-none-win_arm64.whl", hash = "sha256:5ff7d5f0f88567850f45081fac8f4ec212be8d0b963e385c3f7d0d2eb4899416"},
     {file = "ruff-0.15.1.tar.gz", hash = "sha256:c590fe13fb57c97141ae975c03a1aedb3d3156030cabd740d6ff0b0d601e203f"},
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 
 [[package]]
@@ -1301,4 +1338,4 @@ test = ["pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.13"
-content-hash = "5ee05561d937ac60495a0ae656236a99bcd75c26ab53e4f0916ddac194869dc6"
+content-hash = "40c5120934412935a0387f3d22ee25b919f41b2ee03b261fbf6b889d9b6a3ed2"

--- a/app/pyproject.toml
+++ b/app/pyproject.toml
@@ -15,6 +15,10 @@ ruff = "^0.15.1"
 mypy = "^1.16.0"
 pytest = "^9.1.1"
 pytest-cov = "^7.1.0"
+# Redisのデータ構造(ハッシュ/リスト/blpop)そのものが検証対象になるモジュールが
+# あるため、mockではなく実際にコマンドを実行できるfakeredisを使っている。
+# testcontainersを採用しなかった理由はCLAUDE.md参照。
+fakeredis = "^2.33.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/app/routers/youtube_download_router.py
+++ b/app/routers/youtube_download_router.py
@@ -1,22 +1,11 @@
-import json
-import uuid
-from pathlib import Path
-
 import redis
-from fastapi import APIRouter, BackgroundTasks, Request
+from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-from yt_dlp import YoutubeDL  # type: ignore[import]
 
-from core.log_modules import log_application
-from settings.config import settings
+from modules import download_queue
 
 router = APIRouter(tags=["Youtube Download"])
-
-logger = log_application(__name__)
-
-REDIS_QUEUE_KEY = "youtube_download_queue"
-REDIS_STATUS_KEY = "youtube_download_statuses"
 
 
 class YoutubeDownload(BaseModel):
@@ -26,118 +15,40 @@ class YoutubeDownload(BaseModel):
 
 
 @router.post("/download")
-def download(sp_args: YoutubeDownload, background_tasks: BackgroundTasks, request: Request) -> JSONResponse:
+def download(sp_args: YoutubeDownload, request: Request) -> JSONResponse:
+    # キューへ積むだけで、実際のダウンロードは lifespan で起動した常駐ワーカーが行う。
     try:
-        redis_client = request.app.state.redis
-        task_id = str(uuid.uuid4())
-        redis_client.hset(REDIS_STATUS_KEY, task_id, json.dumps({"status": "queued", "error": None}))
-        redis_client.rpush(REDIS_QUEUE_KEY, json.dumps({"task_id": task_id, "url": sp_args.url}))
-        background_tasks.add_task(process_queue, request)
-        return JSONResponse({"task_id": task_id, "message": "キューに登録しました"})
+        task_id = download_queue.enqueue(request.app.state.redis, sp_args.url)
     except redis.exceptions.ConnectionError as e:
         # Redisに接続できない場合のエラー応答
         return JSONResponse({"error": "Redisに接続できません", "detail": str(e)}, status_code=503)
     except redis.exceptions.RedisError as e:
         # その他のRedis関連エラー
         return JSONResponse({"error": "Redisエラー", "detail": str(e)}, status_code=500)
+    return JSONResponse({"task_id": task_id, "message": "キューに登録しました"})
 
 
 @router.get("/download/status")
 def download_status(request: Request) -> JSONResponse:
     try:
-        redis_client = request.app.state.redis
-        statuses = redis_client.hgetall(REDIS_STATUS_KEY)
-        return JSONResponse({k: json.loads(v) for k, v in statuses.items()})
+        statuses = download_queue.fetch_statuses(request.app.state.redis)
     except redis.exceptions.ConnectionError as e:
         return JSONResponse({"error": "Redisに接続できません", "detail": str(e)}, status_code=503)
     except redis.exceptions.RedisError as e:
         return JSONResponse({"error": "Redisエラー", "detail": str(e)}, status_code=500)
     except Exception as e:
         return JSONResponse({"error": "不明なエラー", "detail": str(e)}, status_code=500)
+    return JSONResponse(statuses)
 
 
 @router.delete("/download/all")
 def delete_all_downloads(request: Request) -> JSONResponse:
     try:
-        redis_client = request.app.state.redis
-        # ステータスハッシュのフィールドを削除
-        statuses = redis_client.hgetall(REDIS_STATUS_KEY)
-        if statuses:
-            redis_client.hdel(REDIS_STATUS_KEY, *statuses.keys())
-        return JSONResponse({"message": "すべてのステータスを削除しました"})
+        download_queue.clear_all(request.app.state.redis)
     except redis.exceptions.ConnectionError as e:
         return JSONResponse({"error": "Redisに接続できません", "detail": str(e)}, status_code=503)
     except redis.exceptions.RedisError as e:
         return JSONResponse({"error": "Redisエラー", "detail": str(e)}, status_code=500)
     except Exception as e:
         return JSONResponse({"error": "不明なエラー", "detail": str(e)}, status_code=500)
-
-
-def process_queue(request: Request) -> None:
-    try:
-        redis_client = request.app.state.redis
-        while True:
-            try:
-                item = redis_client.lpop(REDIS_QUEUE_KEY)
-            except redis.exceptions.ConnectionError:
-                # ログ出力や通知など
-                logger.exception("Redis接続エラー")
-                break
-            except redis.exceptions.RedisError:
-                logger.exception("Redisエラー")
-                break
-
-            if not item:
-                break
-            data = json.loads(item)
-            task_id = data["task_id"]
-            url = data["url"]
-
-            try:
-                video_title = get_youtube_title(url)
-                redis_client.hset(
-                    REDIS_STATUS_KEY,
-                    task_id,
-                    json.dumps({"status": "processing", "error": None, "title": video_title}),
-                )
-                download_youtube(url, settings.output_dir)
-                redis_client.hset(
-                    REDIS_STATUS_KEY,
-                    task_id,
-                    json.dumps({"status": "done", "error": None, "title": video_title}),
-                )
-            except Exception as e:
-                redis_client.hset(
-                    REDIS_STATUS_KEY,
-                    task_id,
-                    json.dumps(
-                        {
-                            "status": "error",
-                            "error": str(e),
-                            "title": video_title if "video_title" in locals() else "unknown",
-                        },
-                    ),
-                )
-    except Exception:
-        # Redis自体の初期取得失敗やその他例外
-        logger.exception("process_queue全体でのエラー")
-
-
-def download_youtube(url: str, output_dir: str) -> None:
-    path_out_dir = Path(output_dir)
-    ydl_opts = {
-        "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
-        "outtmpl": str(path_out_dir / "%(title).50s.mp4"),
-        "merge_output_format": "mp4",
-        "postprocessors": [],
-    }
-    with YoutubeDL(ydl_opts) as ydl:
-        ydl.download([url])
-
-
-def get_youtube_title(url: str) -> str:
-    with YoutubeDL({"quiet": True}) as ydl:
-        info = ydl.extract_info(url, download=False)
-        # yt-dlpは型スタブを持たずextract_infoの戻り値がAnyになるため、
-        # str()で明示的に確定させる(mypyのwarn_return_any対策も兼ねる)。
-        return str(info.get("title", "unknown"))
+    return JSONResponse({"message": "すべてのステータスと未処理のキューを削除しました"})

--- a/app/settings/config.py
+++ b/app/settings/config.py
@@ -14,6 +14,15 @@ class Settings(BaseSettings):
     prefix_url: str = Field(default="")
     output_dir: str = Field(default="/data")
 
+    # 常駐ワーカーの本数 = 同時にダウンロードが走る上限
+    download_workers: int = Field(default=1)
+    # ワーカーがキューを待つ時間。この値がそのままシャットダウンの最大待ち時間になる
+    queue_pop_timeout_seconds: int = Field(default=5)
+    # Redisへの接続が切れている間、ワーカーが再試行するまでの待ち時間
+    queue_error_backoff_seconds: float = Field(default=5)
+    # シャットダウン時、処理中のダウンロードの完了を待つ上限
+    worker_shutdown_timeout_seconds: float = Field(default=30)
+
     redis_host: str = Field(default="redis-service")
     redis_port: int = Field(default=6379)
     redis_max_connections: int = Field(default=10)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,12 @@
+import fakeredis
+import pytest
+
+
+@pytest.fixture
+def fake_redis() -> fakeredis.FakeRedis:
+    """テストごとに独立したインメモリRedis。
+
+    decode_responses=True は本番の RedisConnector と揃えている(揃えないと
+    bytes と str の差でテストだけ通る/落ちるという食い違いが起きる)。
+    """
+    return fakeredis.FakeRedis(decode_responses=True)

--- a/app/tests/test_download_queue.py
+++ b/app/tests/test_download_queue.py
@@ -1,0 +1,292 @@
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+import fakeredis
+import pytest
+from redis import RedisError
+
+from modules import download_queue as dq
+from settings.config import settings
+
+
+def _loads(raw: object) -> Any:
+    """Redisから読んだ値をJSONとして解釈する(Noneでないことも併せて検査する)。"""
+    assert isinstance(raw, str)
+    return json.loads(raw)
+
+
+def _status(fake_redis: fakeredis.FakeRedis, task_id: str) -> dict[str, Any]:
+    payload: dict[str, Any] = _loads(fake_redis.hget(dq.REDIS_STATUS_KEY, task_id))
+    return payload
+
+
+async def _wait_until(predicate: Callable[[], bool], timeout: float = 5.0) -> bool:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.02)
+    return False
+
+
+class TestWriteStatus:
+    def test_queued_payload_has_no_title_key(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.write_status(fake_redis, "task-1", "queued")
+
+        # home-discord-bot は title が無いとき「タイトル取得中」へフォールバックする。
+        # ここで title: null を書いてしまうとボットの表示が壊れるため、キーごと省く。
+        assert _status(fake_redis, "task-1") == {"status": "queued", "error": None}
+
+    def test_payload_keys_match_the_bot_contract(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.write_status(fake_redis, "task-1", "done", title="サンプル動画")
+
+        assert _status(fake_redis, "task-1") == {"status": "done", "error": None, "title": "サンプル動画"}
+
+    def test_error_payload_carries_message_and_title(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.write_status(fake_redis, "task-1", "error", title="サンプル動画", error="boom")
+
+        assert _status(fake_redis, "task-1") == {"status": "error", "error": "boom", "title": "サンプル動画"}
+
+    def test_status_is_overwritten_in_place(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.write_status(fake_redis, "task-1", "queued")
+        dq.write_status(fake_redis, "task-1", "processing", title="サンプル動画")
+
+        assert fake_redis.hlen(dq.REDIS_STATUS_KEY) == 1
+        assert _status(fake_redis, "task-1")["status"] == "processing"
+
+
+class TestEnqueue:
+    def test_registers_status_and_queue_entry(self, fake_redis: fakeredis.FakeRedis) -> None:
+        task_id = dq.enqueue(fake_redis, "https://example.test/v")
+
+        assert _status(fake_redis, task_id)["status"] == "queued"
+        assert fake_redis.llen(dq.REDIS_QUEUE_KEY) == 1
+        assert _loads(fake_redis.lindex(dq.REDIS_QUEUE_KEY, 0)) == {
+            "task_id": task_id,
+            "url": "https://example.test/v",
+        }
+
+    def test_task_ids_are_unique(self, fake_redis: fakeredis.FakeRedis) -> None:
+        ids = {dq.enqueue(fake_redis, "https://example.test/v") for _ in range(5)}
+
+        assert len(ids) == 5
+
+    def test_queue_preserves_fifo_order(self, fake_redis: fakeredis.FakeRedis) -> None:
+        first = dq.enqueue(fake_redis, "https://example.test/1")
+        dq.enqueue(fake_redis, "https://example.test/2")
+
+        assert dq.pop_job(fake_redis) == {"task_id": first, "url": "https://example.test/1"}
+
+
+class TestFetchStatuses:
+    def test_returns_all_tasks_as_parsed_dicts(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.write_status(fake_redis, "task-1", "queued")
+        dq.write_status(fake_redis, "task-2", "done", title="サンプル動画")
+
+        statuses = dq.fetch_statuses(fake_redis)
+
+        assert set(statuses) == {"task-1", "task-2"}
+        assert statuses["task-2"]["title"] == "サンプル動画"
+
+    def test_returns_empty_dict_when_no_tasks(self, fake_redis: fakeredis.FakeRedis) -> None:
+        assert dq.fetch_statuses(fake_redis) == {}
+
+
+class TestClearAll:
+    def test_removes_both_statuses_and_pending_queue(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.enqueue(fake_redis, "https://example.test/v")
+
+        dq.clear_all(fake_redis)
+
+        # ステータスだけ消すとキューのジョブが「状態の無いジョブ」として
+        # 後から処理されてしまうため、キューも必ず一緒に消す。
+        assert fake_redis.hgetall(dq.REDIS_STATUS_KEY) == {}
+        assert fake_redis.llen(dq.REDIS_QUEUE_KEY) == 0
+
+    def test_is_noop_when_already_empty(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.clear_all(fake_redis)
+
+        assert fake_redis.hgetall(dq.REDIS_STATUS_KEY) == {}
+
+
+class TestPopJob:
+    def test_returns_none_when_queue_is_empty(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "queue_pop_timeout_seconds", 1)
+
+        assert dq.pop_job(fake_redis) is None
+
+    def test_removes_the_job_from_the_queue(self, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.enqueue(fake_redis, "https://example.test/v")
+
+        dq.pop_job(fake_redis)
+
+        assert fake_redis.llen(dq.REDIS_QUEUE_KEY) == 0
+
+
+class TestProcessJob:
+    def test_transitions_to_done(self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dq, "get_youtube_title", lambda _url: "サンプル動画")
+        monkeypatch.setattr(dq, "download_youtube", lambda _url, _dir: None)
+
+        dq.process_job(fake_redis, {"task_id": "task-1", "url": "https://example.test/v"})
+
+        assert _status(fake_redis, "task-1") == {"status": "done", "error": None, "title": "サンプル動画"}
+
+    def test_writes_processing_before_downloading(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[str] = []
+
+        def _download(_url: str, _dir: str) -> None:
+            seen.append(_status(fake_redis, "task-1")["status"])
+
+        monkeypatch.setattr(dq, "get_youtube_title", lambda _url: "サンプル動画")
+        monkeypatch.setattr(dq, "download_youtube", _download)
+
+        dq.process_job(fake_redis, {"task_id": "task-1", "url": "https://example.test/v"})
+
+        assert seen == ["processing"]
+
+    def test_download_failure_keeps_resolved_title(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _download(_url: str, _dir: str) -> None:
+            raise RuntimeError("ダウンロード失敗")
+
+        monkeypatch.setattr(dq, "get_youtube_title", lambda _url: "サンプル動画")
+        monkeypatch.setattr(dq, "download_youtube", _download)
+
+        dq.process_job(fake_redis, {"task_id": "task-1", "url": "https://example.test/v"})
+
+        assert _status(fake_redis, "task-1") == {
+            "status": "error",
+            "error": "ダウンロード失敗",
+            "title": "サンプル動画",
+        }
+
+    def test_failure_before_title_is_resolved_falls_back_to_unknown(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _title(_url: str) -> str:
+            raise RuntimeError("タイトル取得に失敗")
+
+        monkeypatch.setattr(dq, "get_youtube_title", _title)
+
+        dq.process_job(fake_redis, {"task_id": "task-1", "url": "https://example.test/v"})
+
+        # 旧実装が locals() を覗いて判定していた分岐に相当する
+        assert _status(fake_redis, "task-1")["title"] == "unknown"
+        assert _status(fake_redis, "task-1")["status"] == "error"
+
+    def test_does_not_raise_on_failure(self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _title(_url: str) -> str:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(dq, "get_youtube_title", _title)
+
+        # 呼び出し元(ワーカー)を落とさないこと
+        dq.process_job(fake_redis, {"task_id": "task-1", "url": "https://example.test/v"})
+
+
+class TestRunWorker:
+    """常駐ワーカーの検証。
+
+    ワーカーはキューが空でも回り続けるので、テストごとに停止フラグを立てて
+    確実に終了させる。blpop の待ち時間は短く上書きし、テストが遅くならない
+    ようにしている。
+    """
+
+    @staticmethod
+    def _drive(fake_redis: fakeredis.FakeRedis, predicate: Callable[[], bool], timeout: float = 5.0) -> bool:
+        async def _scenario() -> bool:
+            stop_event = asyncio.Event()
+            task = asyncio.create_task(dq.run_worker(fake_redis, stop_event, "test-worker"))
+            try:
+                return await _wait_until(predicate, timeout)
+            finally:
+                stop_event.set()
+                await asyncio.wait_for(task, timeout=10)
+
+        return asyncio.run(_scenario())
+
+    def test_processes_a_job_already_in_the_queue(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "queue_pop_timeout_seconds", 1)
+        monkeypatch.setattr(dq, "get_youtube_title", lambda _url: "サンプル動画")
+        monkeypatch.setattr(dq, "download_youtube", lambda _url, _dir: None)
+        task_id = dq.enqueue(fake_redis, "https://example.test/v")
+
+        # 起動時点で既に積まれていたジョブが、POSTを一切受けずに処理されること。
+        # 旧実装(BackgroundTasks)ではPOSTが来るまで処理されなかった。
+        done = self._drive(fake_redis, lambda: _status(fake_redis, task_id)["status"] == "done")
+
+        assert done
+
+    def test_keeps_running_after_a_failing_job(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "queue_pop_timeout_seconds", 1)
+        monkeypatch.setattr(dq, "download_youtube", lambda _url, _dir: None)
+        monkeypatch.setattr(
+            dq,
+            "get_youtube_title",
+            lambda url: (_ for _ in ()).throw(RuntimeError("boom")) if "bad" in url else "サンプル動画",
+        )
+        bad = dq.enqueue(fake_redis, "https://example.test/bad")
+        good = dq.enqueue(fake_redis, "https://example.test/good")
+
+        # 1件目の失敗でワーカーが抜けると2件目が永久に処理されない
+        finished = self._drive(
+            fake_redis,
+            lambda: _status(fake_redis, bad)["status"] == "error" and _status(fake_redis, good)["status"] == "done",
+        )
+
+        assert finished
+
+    def test_retries_after_a_redis_error(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "queue_pop_timeout_seconds", 1)
+        monkeypatch.setattr(settings, "queue_error_backoff_seconds", 0.05)
+        monkeypatch.setattr(dq, "get_youtube_title", lambda _url: "サンプル動画")
+        monkeypatch.setattr(dq, "download_youtube", lambda _url, _dir: None)
+
+        calls = {"count": 0}
+        real_pop = dq.pop_job
+
+        def _flaky_pop(client: fakeredis.FakeRedis) -> dict | None:
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RedisError("接続できません")
+            return real_pop(client)
+
+        monkeypatch.setattr(dq, "pop_job", _flaky_pop)
+        task_id = dq.enqueue(fake_redis, "https://example.test/v")
+
+        # Redisエラーでループを抜けてしまうと、以降のジョブが一切消化されなくなる
+        done = self._drive(fake_redis, lambda: _status(fake_redis, task_id)["status"] == "done")
+
+        assert done
+        assert calls["count"] >= 2
+
+    def test_stops_when_the_stop_event_is_set(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "queue_pop_timeout_seconds", 1)
+
+        async def _scenario() -> None:
+            stop_event = asyncio.Event()
+            task = asyncio.create_task(dq.run_worker(fake_redis, stop_event, "test-worker"))
+            await asyncio.sleep(0.1)
+            stop_event.set()
+            # blpop のタイムアウト内に自力で終了すること(キャンセル不要)
+            await asyncio.wait_for(task, timeout=10)
+            assert task.done()
+            assert not task.cancelled()
+
+        asyncio.run(_scenario())

--- a/app/tests/test_log_modules.py
+++ b/app/tests/test_log_modules.py
@@ -1,0 +1,75 @@
+import io
+import json
+import logging
+
+from core.log_modules import LogApplicationJSONFormatter, TimeStampFormatter, log_application
+
+
+def _make_logger(name: str) -> tuple[logging.Logger, io.StringIO]:
+    stream = io.StringIO()
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(LogApplicationJSONFormatter())
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger, stream
+
+
+class TestTimeStampFormatter:
+    def test_format_time_uses_configured_timezone(self) -> None:
+        formatter = TimeStampFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname=__file__, lineno=1, msg="msg", args=(), exc_info=None
+        )
+        record.created = 0
+
+        # settings.tz のデフォルトは Asia/Tokyo (UTC+9) のため、epoch は 09:00 になる。
+        # OS側のtzdataではなくPythonのtzdataパッケージで解決されるため、
+        # 最小構成のコンテナイメージでもこの結果は変わらない。
+        assert formatter.formatTime(record).startswith("1970-01-01T09:00:00")
+
+
+class TestLogApplicationJSONFormatter:
+    def test_emits_valid_json_with_expected_fields(self) -> None:
+        logger, stream = _make_logger("test.log_modules.basic")
+
+        logger.info("こんにちは")
+
+        payload = json.loads(stream.getvalue())
+        assert payload["level"] == "INFO"
+        assert payload["message"] == "こんにちは"
+        assert payload["service"] == "home-api"
+        assert payload["tag"] == "application"
+        assert payload["details"]["error_message"] is None
+        assert payload["details"]["stacktrace"] is None
+
+    def test_includes_exception_details(self) -> None:
+        logger, stream = _make_logger("test.log_modules.exception")
+
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            logger.exception("失敗しました")
+
+        payload = json.loads(stream.getvalue())
+        assert payload["level"] == "ERROR"
+        assert payload["details"]["error_message"] == "boom"
+        assert "ValueError: boom" in payload["details"]["stacktrace"]
+
+    def test_message_is_not_escaped_to_ascii(self) -> None:
+        logger, stream = _make_logger("test.log_modules.unicode")
+
+        logger.info("日本語のメッセージ")
+
+        # ensure_ascii=False で出力しているため、生の日本語がそのまま載る
+        assert "日本語のメッセージ" in stream.getvalue()
+
+
+class TestLogApplication:
+    def test_returns_logger_that_does_not_propagate(self) -> None:
+        logger = log_application("test.log_modules.factory")
+
+        assert logger.propagate is False
+        assert logger.handlers

--- a/app/tests/test_main.py
+++ b/app/tests/test_main.py
@@ -1,0 +1,193 @@
+import asyncio
+import json
+from collections.abc import Callable, Iterator
+from typing import Any
+
+import fakeredis
+import pytest
+from fastapi.testclient import TestClient
+from redis import ConnectionError as RedisConnectionError
+from redis import RedisError
+
+import main
+from modules import download_queue as dq
+from settings.config import settings
+
+
+@pytest.fixture
+def client(fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """ワーカーを起動しないTestClient。
+
+    エンドポイント自体はキューへ積む/読むだけでダウンロードには関与しないため、
+    download_workers=0 にしてワーカーを止めておく。こうするとPOSTしたタスクが
+    テストの最中に勝手に processing へ進まず、アサーションが安定する。
+    ワーカーの検証は test_download_queue.py 側で行う。
+    """
+    monkeypatch.setattr(settings, "download_workers", 0)
+    monkeypatch.setattr(main, "RedisConnector", lambda: _StubConnector(fake_redis))
+    with TestClient(main.app) as test_client:
+        yield test_client
+
+
+class _StubConnector:
+    def __init__(self, conn: fakeredis.FakeRedis) -> None:
+        self._conn = conn
+        self.closed = False
+
+    def get_connection(self) -> fakeredis.FakeRedis:
+        return self._conn
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestLifespan:
+    def test_starts_the_configured_number_of_workers(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "download_workers", 2)
+        monkeypatch.setattr(settings, "queue_pop_timeout_seconds", 1)
+        monkeypatch.setattr(main, "RedisConnector", lambda: _StubConnector(fake_redis))
+
+        started: list[str] = []
+        monkeypatch.setattr(main, "run_worker", _recording_worker(started))
+
+        with TestClient(main.app):
+            pass
+
+        assert len(started) == 2
+
+    def test_closes_redis_on_shutdown(self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "download_workers", 0)
+        connector = _StubConnector(fake_redis)
+        monkeypatch.setattr(main, "RedisConnector", lambda: connector)
+
+        with TestClient(main.app):
+            assert connector.closed is False
+
+        assert connector.closed is True
+
+    def test_exposes_the_connection_on_app_state(
+        self, fake_redis: fakeredis.FakeRedis, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "download_workers", 0)
+        monkeypatch.setattr(main, "RedisConnector", lambda: _StubConnector(fake_redis))
+
+        with TestClient(main.app) as test_client:
+            assert test_client.app.state.redis is fake_redis  # type: ignore[attr-defined]
+
+
+def _recording_worker(started: list[str]) -> Callable[..., Any]:
+    """起動されたワーカー名を記録し、停止フラグが立つまで待つだけのダミーワーカー。"""
+
+    async def _worker(_conn: object, stop_event: asyncio.Event, name: str) -> None:
+        started.append(name)
+        await stop_event.wait()
+
+    return _worker
+
+
+class TestDownloadEndpoint:
+    def test_enqueues_and_returns_task_id(self, client: TestClient, fake_redis: fakeredis.FakeRedis) -> None:
+        res = client.post("/download", json={"url": "https://example.test/v"})
+
+        assert res.status_code == 200
+        task_id = res.json()["task_id"]
+        raw = fake_redis.hget(dq.REDIS_STATUS_KEY, task_id)
+        assert isinstance(raw, str)
+        assert json.loads(raw)["status"] == "queued"
+        assert fake_redis.llen(dq.REDIS_QUEUE_KEY) == 1
+
+    def test_rejects_payload_without_url(self, client: TestClient) -> None:
+        assert client.post("/download", json={}).status_code == 422
+
+    def test_returns_503_when_redis_is_unreachable(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dq, "enqueue", _raiser(RedisConnectionError("接続できません")))
+
+        res = client.post("/download", json={"url": "https://example.test/v"})
+
+        assert res.status_code == 503
+        assert res.json()["error"] == "Redisに接続できません"
+
+    def test_returns_500_on_other_redis_errors(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dq, "enqueue", _raiser(RedisError("boom")))
+
+        assert client.post("/download", json={"url": "https://example.test/v"}).status_code == 500
+
+
+class TestStatusEndpoint:
+    def test_returns_all_statuses(self, client: TestClient, fake_redis: fakeredis.FakeRedis) -> None:
+        dq.write_status(fake_redis, "task-1", "done", title="サンプル動画")
+
+        res = client.get("/download/status")
+
+        assert res.status_code == 200
+        assert res.json() == {"task-1": {"status": "done", "error": None, "title": "サンプル動画"}}
+
+    def test_returns_empty_object_when_no_tasks(self, client: TestClient) -> None:
+        assert client.get("/download/status").json() == {}
+
+    def test_returns_503_when_redis_is_unreachable(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dq, "fetch_statuses", _raiser(RedisConnectionError("接続できません")))
+
+        assert client.get("/download/status").status_code == 503
+
+    def test_returns_500_on_unexpected_error(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dq, "fetch_statuses", _raiser(ValueError("壊れたJSON")))
+
+        res = client.get("/download/status")
+
+        assert res.status_code == 500
+        assert res.json()["error"] == "不明なエラー"
+
+
+class TestDeleteAllEndpoint:
+    def test_clears_statuses_and_queue(self, client: TestClient, fake_redis: fakeredis.FakeRedis) -> None:
+        client.post("/download", json={"url": "https://example.test/v"})
+
+        res = client.delete("/download/all")
+
+        assert res.status_code == 200
+        assert fake_redis.hgetall(dq.REDIS_STATUS_KEY) == {}
+        assert fake_redis.llen(dq.REDIS_QUEUE_KEY) == 0
+
+    def test_returns_503_when_redis_is_unreachable(self, client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dq, "clear_all", _raiser(RedisConnectionError("接続できません")))
+
+        assert client.delete("/download/all").status_code == 503
+
+
+class TestOperationCheckEndpoints:
+    def test_root_redirects_to_docs(self, client: TestClient) -> None:
+        res = client.get("/", follow_redirects=False)
+
+        assert res.status_code == 307
+        assert res.headers["location"].endswith("/docs")
+
+    def test_operation_returns_hello_world(self, client: TestClient) -> None:
+        assert client.get("/operation").json() == {"Hello": "World"}
+
+    def test_operation_ip_returns_hostname_and_ip(self, client: TestClient) -> None:
+        payload = client.get("/operation/ip").json()
+
+        assert set(payload) == {"hostname", "ip"}
+
+    def test_gzip_test_returns_large_payload(self, client: TestClient) -> None:
+        assert len(client.get("/operation/gzip-test").json()["data"]) == 10000
+
+
+class TestOpenApi:
+    def test_schema_is_served(self, client: TestClient) -> None:
+        assert client.get("/openapi.json").status_code == 200
+
+    def test_redoc_is_disabled(self, client: TestClient) -> None:
+        assert client.get("/redoc").status_code == 404
+
+
+def _raiser(exc: Exception) -> Callable[..., Any]:
+    """呼ばれると必ず指定の例外を送出する関数を返す(Redis障害の再現用)。"""
+
+    def _raise(*_args: object, **_kwargs: object) -> Any:
+        raise exc
+
+    return _raise

--- a/app/tests/test_redis_module.py
+++ b/app/tests/test_redis_module.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock, patch
+
+import redis
+
+from modules.redis_module import RedisConnector
+
+
+class TestRedisConnector:
+    def test_get_connection_builds_pool_from_configured_params(self) -> None:
+        connector = RedisConnector(host="redis-host", port=6380, max_connections=5)
+
+        with patch("modules.redis_module.redis.ConnectionPool") as mock_pool_cls:
+            mock_pool_cls.return_value = MagicMock()
+            conn = connector.get_connection()
+
+        mock_pool_cls.assert_called_once_with(
+            host="redis-host",
+            port=6380,
+            max_connections=5,
+            decode_responses=True,
+        )
+        assert isinstance(conn, redis.Redis)
+
+    def test_connection_pool_is_created_only_once(self) -> None:
+        connector = RedisConnector()
+
+        with patch("modules.redis_module.redis.ConnectionPool") as mock_pool_cls:
+            mock_pool_cls.return_value = MagicMock()
+            connector.get_connection()
+            connector.get_connection()
+
+        mock_pool_cls.assert_called_once()
+
+
+class TestClose:
+    def test_close_disconnects_the_pool(self) -> None:
+        connector = RedisConnector()
+
+        with patch("modules.redis_module.redis.ConnectionPool") as mock_pool_cls:
+            pool = MagicMock()
+            mock_pool_cls.return_value = pool
+            connector.get_connection()
+            connector.close()
+
+        pool.disconnect.assert_called_once()
+
+    def test_close_without_connection_is_noop(self) -> None:
+        # プールを一度も作っていない状態で呼ばれても落ちないこと
+        RedisConnector().close()
+
+    def test_pool_is_rebuilt_after_close(self) -> None:
+        connector = RedisConnector()
+
+        with patch("modules.redis_module.redis.ConnectionPool") as mock_pool_cls:
+            mock_pool_cls.return_value = MagicMock()
+            connector.get_connection()
+            connector.close()
+            connector.get_connection()
+
+        assert mock_pool_cls.call_count == 2

--- a/app/tests/test_youtube_module.py
+++ b/app/tests/test_youtube_module.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock, patch
+
+from modules.youtube_module import download_youtube, get_youtube_title
+
+
+def _patched_ydl() -> tuple[MagicMock, MagicMock]:
+    """YoutubeDL をモックし、(クラスのモック, インスタンスのモック) を返す。"""
+    ydl_cls = MagicMock()
+    instance = MagicMock()
+    ydl_cls.return_value.__enter__.return_value = instance
+    return ydl_cls, instance
+
+
+class TestDownloadYoutube:
+    def test_passes_expected_options_to_ytdlp(self) -> None:
+        ydl_cls, instance = _patched_ydl()
+
+        with patch("modules.youtube_module.YoutubeDL", ydl_cls):
+            download_youtube("https://example.test/v", "/data")
+
+        opts = ydl_cls.call_args.args[0]
+        assert opts["merge_output_format"] == "mp4"
+        # ファイル名が長くなりすぎないようタイトルを50文字で切っている
+        assert opts["outtmpl"] == "/data/%(title).50s.mp4"
+        instance.download.assert_called_once_with(["https://example.test/v"])
+
+    def test_output_dir_is_joined_as_path(self) -> None:
+        ydl_cls, _ = _patched_ydl()
+
+        with patch("modules.youtube_module.YoutubeDL", ydl_cls):
+            download_youtube("https://example.test/v", "/mnt/videos/")
+
+        assert ydl_cls.call_args.args[0]["outtmpl"] == "/mnt/videos/%(title).50s.mp4"
+
+
+class TestGetYoutubeTitle:
+    def test_returns_title_without_downloading(self) -> None:
+        ydl_cls, instance = _patched_ydl()
+        instance.extract_info.return_value = {"title": "サンプル動画"}
+
+        with patch("modules.youtube_module.YoutubeDL", ydl_cls):
+            assert get_youtube_title("https://example.test/v") == "サンプル動画"
+
+        instance.extract_info.assert_called_once_with("https://example.test/v", download=False)
+
+    def test_falls_back_to_unknown_when_title_is_missing(self) -> None:
+        ydl_cls, instance = _patched_ydl()
+        instance.extract_info.return_value = {}
+
+        with patch("modules.youtube_module.YoutubeDL", ydl_cls):
+            assert get_youtube_title("https://example.test/v") == "unknown"
+
+    def test_non_string_title_is_coerced_to_str(self) -> None:
+        ydl_cls, instance = _patched_ydl()
+        instance.extract_info.return_value = {"title": 12345}
+
+        with patch("modules.youtube_module.YoutubeDL", ydl_cls):
+            title = get_youtube_title("https://example.test/v")
+
+        assert title == "12345"
+        assert isinstance(title, str)


### PR DESCRIPTION
技術的負債のうち **「アプリ設計上の課題」6点** と **「テストファイルが1件も無い」** を解消します。設計変更とその検証を同じPRに含めています。

**Redisのステータスハッシュのスキーマ(`status`/`error`/`title`)は `ssmc-network/home-discord-bot` との契約なので一切変更していません。** ボット側の実装（`title` が無い場合は「タイトル取得中」へフォールバック、タスクがハッシュから消えたら通知済み状態も追従して片付ける）も確認した上で互換性を保ち、テストでも契約として固定しています。

---

# 1/2. アプリ設計上の課題を解消（コミット `4ef5ebf`）

### ① キューの消化をリクエスト駆動から常駐ワーカーへ

`lifespan` が `settings.download_workers` 本（既定1）のワーカータスクを起動し、各ワーカーが `blpop` でキューを待ち受けます。`POST /download` はキューへ積むだけになりました。

従来は `BackgroundTasks` で `process_queue` を起動していたため、**POSTが来ないと積まれたジョブが処理されず、逆に同時POSTの分だけ無制限に並列ダウンロードが走る**状態でした。今後はワーカー本数がそのまま同時実行数の上限になります。

`blpop` も yt-dlp のダウンロードもブロッキングなので、どちらも `asyncio.to_thread` でスレッドへ逃がし、イベントループを止めないようにしています。

### ② `Request` オブジェクトの引き回しを廃止

ワーカーは `lifespan` で生成したRedis接続を直接受け取ります。レスポンス送出後に `request.app.state.redis` を参照することがなくなりました。

### ③ `locals()` を使った実装を廃止

`video_title` を `try` の前で `"unknown"` に初期化することで、`video_title if "video_title" in locals() else "unknown"` を不要にしました。

### ④ `RedisConnector` のデッドコードを削除

ConnectionPoolの生成はソケット接続を伴わない（実際の接続は最初のコマンド発行時）ため、生成時の `redis.ConnectionError` を捕まえて `HTTPException` を投げる処理は到達しません。兄弟リポジトリと同じく、理由をコメントに残して削除しました。

### ⑤ `lifespan` に終了処理を追加

停止フラグを立て、処理中のダウンロードの完了を `settings.worker_shutdown_timeout_seconds`（既定30秒）まで待ってから、待ち切れなかったワーカーだけキャンセルします。その後 `RedisConnector.close()` でプールを切断します。

### ⑥ `DELETE /download/all` がキューも削除するよう変更

ステータスだけを消すとキューに残ったジョブが後から「状態の無いジョブ」として処理されてしまうためです。ボットの `youtube_download_notified_statuses` はボット側の管轄なので触っていません。

### 責務の分離

| ファイル | 責務 |
| --- | --- |
| `routers/youtube_download_router.py` | HTTP層のみ（3エンドポイント） |
| `modules/download_queue.py` (新規) | キュー/ステータスの読み書き、常駐ワーカー |
| `modules/youtube_module.py` (新規) | yt-dlpの呼び出し |

ワーカーはジョブ1件の失敗やRedisの接続エラーでは**ループを抜けません**。常駐ワーカーがループを抜けると以降のジョブが一切消化されなくなるためです（接続エラーは `queue_error_backoff_seconds` 待って再試行）。

### 追加した設定

| 設定 | 既定値 | 用途 |
| --- | --- | --- |
| `download_workers` | 1 | 常駐ワーカーの本数 = 同時ダウンロード数の上限 |
| `queue_pop_timeout_seconds` | 5 | `blpop` の待ち時間。シャットダウンの最大待ち時間にもなる |
| `queue_error_backoff_seconds` | 5 | Redis接続エラー時の再試行間隔 |
| `worker_shutdown_timeout_seconds` | 30 | 停止時に処理中のダウンロードを待つ上限 |

---

# 2/2. ユニットテストの整備（コミット `920ed51`）

`app/tests/` 配下に **56件** のテストを追加しました。`test.yaml` の `[ -d tests ]` ガードにより、**この時点からCIでも自動的に `pytest` が走り始めます**（実行時間は約6秒）。

| ファイル | 対象 |
| --- | --- |
| `conftest.py` | テストごとに独立したインメモリRedisを返す `fake_redis` フィクスチャ |
| `test_download_queue.py` | キュー/ステータス操作と常駐ワーカー |
| `test_main.py` | `lifespan` と全エンドポイント |
| `test_redis_module.py` | `RedisConnector` |
| `test_log_modules.py` | JSONログのフォーマット |
| `test_youtube_module.py` | yt-dlpの呼び出し |

### Redisの扱いは対象で使い分けています

- **`download_queue` は fakeredis** — 検証対象がハッシュ・リスト・`blpop` というRedisのデータ構造そのものなので、mockで「`hset` をこの引数で呼んだか」を見るのではなく、**実際にコマンドを実行して結果の状態でアサート**します
- **`RedisConnector` は `unittest.mock`** — 検証対象は「プールを正しいパラメータで1度だけ作るか」でRedisの振る舞いは関係ないため、兄弟リポジトリと同じく `redis.ConnectionPool` をパッチします

### testcontainers を採用しなかった理由

CIは `docker run --rm test-image:latest ... pytest` の形で**テストをコンテナの中で実行している**ため、testcontainers を使うとテストコンテナ内から更にDockerを叩く必要があり、dockerソケットのマウントと `dev` イメージへのdockerクライアント追加が要ります。DHI移行で「本番イメージから余計なものを排除する」方向に進めてきた直後としても、「テストは本番と同じイメージの中で動かす」というCI設計としても逆行します。

加えて `compose.yml` には既に `redis-service` が居るので、ローカルで実Redisを使いたい場合は testcontainers 無しでそこへ繋げば済みます。現在使っているコマンドは `hset`/`hgetall`/`rpush`/`blpop`/`delete` だけで、いずれも fakeredis が忠実に模せる範囲にあります。**Luaスクリプト・Cluster・実際の接続断など fakeredis が模しきれない領域を検証したくなった時点で見直す**旨も CLAUDE.md に記載しました。

`fakeredis` を dev 依存へ追加しています（兄弟リポジトリには無い依存が1つ増えます）。

### 主な検証内容

- **起動時点で既にキューへ積まれていたジョブが、POSTを一切受けずに `done` まで進む**（常駐ワーカー化の中心的な修正点）
- ワーカーがジョブ1件の失敗やRedisエラーでループを抜けない
- 停止フラグでワーカーがキャンセルされることなく自力終了する
- ステータスの値が `queued` では `status`/`error` のみ、それ以降は `status`/`error`/`title` になる（**ボットとの契約**）
- タイトル取得前に失敗した場合に `title` が `"unknown"` になる（旧 `locals()` 実装の分岐に相当）
- `DELETE /download/all` がステータスとキューの両方を消す
- 各エンドポイントのRedis障害時の応答（503/500）
- `lifespan` がワーカーを設定本数だけ起動し、終了時にRedisを閉じる

エンドポイントの検証では `settings.download_workers` を0にしてワーカーを起動しません。起動したままだとPOSTしたタスクがアサート前に `processing` へ進んでしまい、テストが不安定になるためです（実際に検証中この事象を踏みました）。ワーカー自体の検証は `test_download_queue.py` に集約しています。

---

## 動作確認

作業環境に docker デーモンが無いためイメージのビルドはできていませんが、Python 3.13 の仮想環境で以下がすべてパスすることを確認しています。

- `pytest` — **56 passed**（約6秒）
- `ruff check .` / `ruff format --check .`
- `mypy .` — Success: no issues found in 18 source files
- `poetry check --lock`

**Dockerイメージのビルドは未検証で、CIが初回**になります。

## 残りの負債

このPRのマージ後、CLAUDE.md に残るのは以下です。1・2 は保留の指示をいただいています。

1. **uvicorn側のログ設定が無い**（保留中）
2. **mypyをCIで実行していない**（保留中）
3. **複数レプリカ運用時の同時ダウンロード数** — 今回入れた上限は1プロセス内のもので、レプリカ数だけ並列度が倍加します（`blpop` によりジョブの重複処理は起きません）
4. **ダウンロード中にプロセスが落ちるとタスクが `processing` のまま残る** — 厳密にやるなら `lmove` を使う信頼性キューが必要です